### PR TITLE
Adjust Underscore _.flatten types for specific depth (#51077)

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -772,12 +772,12 @@ declare module _ {
          **/
         flatten<V extends List<any>>(
             list: V,
-            depth?: false
-        ): DeepestListItemOrSelf<TypeOfList<V>>[];
+            depth: 1 | true
+        ): ListItemOrSelf<TypeOfList<V>>[];
         flatten<V extends List<any>>(
             list: V,
-            depth: number | true
-        ): ListItemOrSelf<TypeOfList<V>>[];
+            depth?: number | false
+        ): DeepestListItemOrSelf<TypeOfList<V>>[];
 
         /**
          * Returns a copy of `list` with all instances of `values` removed.
@@ -4504,8 +4504,8 @@ declare module _ {
          * default = false.
          * @returns The flattened list.
          **/
-        flatten(depth?: false): DeepestListItemOrSelf<T>[];
-        flatten(depth: true | number): ListItemOrSelf<T>[];
+        flatten(depth: 1 | true): ListItemOrSelf<T>[];
+        flatten(depth?: number | false): DeepestListItemOrSelf<T>[];
 
         /**
          * Returns a copy of the wrapped list with all instances of `values`
@@ -5729,8 +5729,8 @@ declare module _ {
          * default = false.
          * @returns A chain wrapper around the flattened list.
          **/
-        flatten(depth?: false): _Chain<DeepestListItemOrSelf<T>>;
-        flatten(depth: true | number): _Chain<ListItemOrSelf<T>>;
+        flatten(depth: 1 | true): _Chain<ListItemOrSelf<T>>;
+        flatten(depth?: number | false): _Chain<DeepestListItemOrSelf<T>>;
 
         /**
          * Returns a copy of the wrapped list with all instances of `values`

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -2109,8 +2109,8 @@ _.flatten([[[1, 2], [3]], [[4, 5]]]); // $ExpectType any[]
 // shallow flattening an array
 _.flatten([[[1, 2], [3]], [[4, 5]]], true); // $ExpectType number[][]
 
-// shallow flattening an array
-_.flatten([[[1, 2], [3]], [[4, 5]]], 2); // $ExpectType number[][]
+// flattening an array to a particular depth
+_.flatten([[[1, 2], [3]], [[4, 5]]], 2); // $ExpectType any[]
 
 {
     // one dimension, deep


### PR DESCRIPTION
Hey @ffflorian, this is to follow up on my review in the upstream repository. Sorry for the delay.

I made four changes, the first three of which I repeated for each of the three toplevel interfaces:

- `depth` argument for the shallow case from `number | true` to `1 | true`.
- `depth` argument for the deep case from `false` to `number | false`.
- Switched the order: shallow case now comes before the deep case.
- Changed the expected type for `depth` argument of `2`.

This effectively treats all depths greater than 1 as if they are deep, but I think that's fine since we were using `any[]` already due to the recursive types quickly becoming intractable.

If you merge this, it will automatically become part of your PR at the upstream repository. In that case I'll accept immediately. If you decide to do something else, I'll happily review it again, too.